### PR TITLE
Upgrade actions/checkout and actions/cache to latest versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v6.0.2
     - name: Set up JDK 17
       uses: actions/setup-java@v4.0.0
       with:
         distribution: temurin
         java-version: 17
     - name: Cache Maven Dependencies (~/.m2/repository)
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v5.0.3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
- Upgrade GitHub Actions to use newer versions of checkout and cache actions.